### PR TITLE
[PR-14.7] データレジデンシE2E強制検証を追加

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -350,7 +350,7 @@
     - [x] RBAC/ABAC 動的権限変更時の挙動検証
 - [ ] **ガバナンス・ポリシーE2E**:
     - [ ] PIIマスキングの実効性検証: 個人情報を含むデータの投入 -> 検索結果でのマスキング確認
-    - [ ] データレジデンシの強制検証: 指定リージョン外からの要求拒否フロー
+    - [x] データレジデンシの強制検証: 指定リージョン外からの要求拒否フロー
     - [x] 保持期限（Retention）の動的検証: 期限切れデータが検索対象から自動除外されることの確認
 
 **Notes:**
@@ -360,6 +360,7 @@
 - テナント分離E2E (`test_e2e_tenant_isolation_prevents_cross_tenant_leakage`) を追加し、クロステナント混入が発生しないことを検証
 - 動的権限変更E2E (`test_e2e_dynamic_rbac_abac_permission_transition`) を追加し、RBAC更新前後の拒否理由遷移（`PermissionDenied` -> `InsufficientClearance`）とABAC更新後の許可を検証
 - 保持期限E2E (`test_e2e_retention_dynamic_excludes_expired_nodes`) を追加し、ガバナンスポリシー更新後に期限切れデータが `retention_expired` として検索結果から除外されることを検証
+- データレジデンシE2E (`test_e2e_data_residency_enforces_region_boundary`) を追加し、越境リージョン取り込みの `ResidencyViolation` 拒否と同一リージョン取り込み後の検索成功を検証
 
 ---
 

--- a/ingestion/tests/e2e_pipeline_test.rs
+++ b/ingestion/tests/e2e_pipeline_test.rs
@@ -5,9 +5,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use alayasiki_core::auth::{
     Action, Authorizer, AuthzError, JwtAuthenticator, JwtClaims, ResourceContext,
 };
-use alayasiki_core::governance::{InMemoryGovernancePolicyStore, TenantGovernancePolicy};
+use alayasiki_core::governance::{
+    GovernanceError, InMemoryGovernancePolicyStore, TenantGovernancePolicy,
+};
 use alayasiki_core::ingest::IngestionRequest;
-use ingestion::processor::IngestionPipeline;
+use ingestion::processor::{IngestionError, IngestionPipeline};
 use jobs::queue::ChannelJobQueue;
 use jobs::worker::Worker;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
@@ -678,6 +680,112 @@ async fn test_e2e_retention_dynamic_excludes_expired_nodes() {
         .exclusions
         .iter()
         .any(|reason| reason.reason == "retention_expired"));
+}
+
+#[tokio::test]
+async fn test_e2e_data_residency_enforces_region_boundary() {
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("e2e_residency_enforcement.wal");
+    let repo = Arc::new(Repository::open(&wal_path).await.unwrap());
+
+    let policy_store = Arc::new(InMemoryGovernancePolicyStore::default());
+    policy_store
+        .upsert_policy(TenantGovernancePolicy::new("acme", "ap-northeast-1", 30))
+        .unwrap();
+
+    let pipeline =
+        IngestionPipeline::new(repo.clone()).with_governance_policy_store(policy_store.clone());
+    let engine = QueryEngine::new(repo);
+
+    let secret = "jwt-e2e-residency-secret";
+    let token = issue_test_token(secret, "acme", &["admin"], "ingest:write query:execute");
+    let authenticator =
+        JwtAuthenticator::new_hs256(secret, Some("alayasiki-auth"), Some("alayasiki-api"));
+    let authorizer = Authorizer::default();
+    let resource = ResourceContext::new("acme");
+
+    let out_of_region_err = pipeline
+        .ingest_jwt_authorized(
+            IngestionRequest::Text {
+                content: "Residency blocked document".to_string(),
+                metadata: HashMap::from([
+                    (
+                        "source".to_string(),
+                        "tenant/acme-residency-blocked.md".to_string(),
+                    ),
+                    ("region".to_string(), "us-east-1".to_string()),
+                ]),
+                idempotency_key: Some("tenant-acme-residency-blocked".to_string()),
+                model_id: Some("embedding-default-v1".to_string()),
+            },
+            &token,
+            &authenticator,
+            &authorizer,
+            &resource,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        out_of_region_err,
+        IngestionError::Governance(GovernanceError::ResidencyViolation {
+            tenant,
+            expected_region,
+            actual_region
+        }) if tenant == "acme"
+            && expected_region == "ap-northeast-1"
+            && actual_region == "us-east-1"
+    ));
+
+    pipeline
+        .ingest_jwt_authorized(
+            IngestionRequest::Text {
+                content: "Residency allowed document".to_string(),
+                metadata: HashMap::from([
+                    (
+                        "source".to_string(),
+                        "tenant/acme-residency-allowed.md".to_string(),
+                    ),
+                    ("region".to_string(), "ap-northeast-1".to_string()),
+                ]),
+                idempotency_key: Some("tenant-acme-residency-allowed".to_string()),
+                model_id: Some("embedding-default-v1".to_string()),
+            },
+            &token,
+            &authenticator,
+            &authorizer,
+            &resource,
+        )
+        .await
+        .unwrap();
+
+    let response = engine
+        .execute_json_jwt_authorized(
+            r#"{
+                "query":"residency document",
+                "mode":"evidence",
+                "search_mode":"local",
+                "top_k":10
+            }"#,
+            &token,
+            &authenticator,
+            &authorizer,
+            &resource,
+        )
+        .await
+        .unwrap();
+
+    assert!(!response.evidence.nodes.is_empty());
+    assert!(response
+        .evidence
+        .nodes
+        .iter()
+        .any(|node| node.data.contains("Residency allowed document")));
+    assert!(response
+        .evidence
+        .nodes
+        .iter()
+        .all(|node| !node.data.contains("Residency blocked document")));
 }
 
 async fn wait_for_min_graph_edges(repo: &Arc<Repository>, min_edges: usize, timeout: Duration) {


### PR DESCRIPTION
## 概要
PR-14.7 の未完了項目「データレジデンシの強制検証」を E2E で実装しました。JWT 認可 ingest 経路で越境リージョンを拒否し、同一リージョンのみ取り込み・検索可能であることを一気通貫で検証します。

## 変更内容
- `ingestion/tests/e2e_pipeline_test.rs`
  - `test_e2e_data_residency_enforces_region_boundary` を追加
  - 越境リージョン (`us-east-1`) ingest が `IngestionError::Governance(GovernanceError::ResidencyViolation)` で失敗することを検証
  - 正常リージョン (`ap-northeast-1`) ingest 後に query でデータ取得できることを検証
- `docs/PLAN.md`
  - PR-14.7 の「データレジデンシの強制検証」を `[x]` に更新
  - 新規E2Eテストに関する Note を追記

## Exit Criteria
- [x] 指定リージョン外からの取り込み要求を拒否できる
- [x] 指定リージョン内の取り込みは許可され、検索で観測できる
- [x] PR-14.7 の該当タスクが `docs/PLAN.md` に反映されている

## 実行コマンド
- `cargo test -p ingestion --test e2e_pipeline_test test_e2e_data_residency_enforces_region_boundary -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p ingestion --test e2e_pipeline_test -- --nocapture`

## 結果
上記コマンドはすべてローカルで成功しました。
