### PR TITLE
[PR-14.6] ingest write-path batching for latency

### DIFF
--- a/benchmarks/benchmark_suite.py
+++ b/benchmarks/benchmark_suite.py
@@ -299,6 +299,7 @@ def extract_operational_metrics(result: dict[str, Any]) -> dict[str, Any]:
     totals = result.get("totals", {})
     read_latency = result.get("read_latency_ns", {})
     write_latency = result.get("write_latency_ns", {})
+    durability_barrier = result.get("durability_barrier", {})
     return {
         "nodes": config.get("nodes", 0),
         "workers": config.get("workers", 0),
@@ -307,11 +308,13 @@ def extract_operational_metrics(result: dict[str, Any]) -> dict[str, Any]:
         "read_to_write_ratio": config.get("read_to_write_ratio", ""),
         "wal_flush_policy": config.get("wal_flush_policy", ""),
         "seed_wal_flush_policy": config.get("seed_wal_flush_policy", ""),
+        "write_latency_scope": config.get("write_latency_scope", ""),
         "throughput_ops_per_sec": totals.get("throughput_ops_per_sec", 0.0),
-        "read_p95_ms": read_latency.get("p95_ms", 0.0),
-        "write_p95_ms": write_latency.get("p95_ms", 0.0),
-        "read_p99_ms": read_latency.get("p99_ms", 0.0),
-        "write_p99_ms": write_latency.get("p99_ms", 0.0),
+        "read_p95_ms": read_latency.get("p95_ms"),
+        "write_p95_ms": write_latency.get("p95_ms"),
+        "read_p99_ms": read_latency.get("p99_ms"),
+        "write_p99_ms": write_latency.get("p99_ms"),
+        "final_flush_ms": durability_barrier.get("final_flush_ms"),
     }
 
 
@@ -322,14 +325,37 @@ def validate_operational_metrics(metrics: dict[str, Any], scenario_slug: str) ->
         "read_to_write_ratio",
         "wal_flush_policy",
         "seed_wal_flush_policy",
+        "write_latency_scope",
     )
     missing_text = [field for field in required_text_fields if not metrics[field]]
-    if missing_numeric or missing_text or metrics["throughput_ops_per_sec"] <= 0.0:
+    required_latency_fields = (
+        "read_p95_ms",
+        "write_p95_ms",
+        "read_p99_ms",
+        "write_p99_ms",
+    )
+    missing_latency = [
+        field
+        for field in required_latency_fields
+        if not isinstance(metrics[field], (int, float)) or metrics[field] <= 0.0
+    ]
+    invalid_final_flush = not isinstance(metrics["final_flush_ms"], (int, float))
+    if (
+        missing_numeric
+        or missing_text
+        or missing_latency
+        or invalid_final_flush
+        or metrics["throughput_ops_per_sec"] <= 0.0
+    ):
         details = []
         if missing_numeric:
             details.append(f"numeric={','.join(missing_numeric)}")
         if missing_text:
             details.append(f"text={','.join(missing_text)}")
+        if missing_latency:
+            details.append(f"latency={','.join(missing_latency)}")
+        if invalid_final_flush:
+            details.append("final_flush_ms_missing")
         if metrics["throughput_ops_per_sec"] <= 0.0:
             details.append("throughput_ops_per_sec<=0")
         raise ValueError(
@@ -368,12 +394,19 @@ def build_pr14_6_operational_report(
             }
             if baseline_metrics is None:
                 baseline_metrics = metrics
+                row["write_latency_comparable_to_baseline"] = True
                 row["delta_vs_baseline"] = {
                     "throughput_pct": 0.0,
                     "read_p95_ms": 0.0,
                     "write_p95_ms": 0.0,
+                    "final_flush_ms": 0.0,
                 }
             else:
+                write_latency_comparable = (
+                    metrics["write_latency_scope"]
+                    == baseline_metrics["write_latency_scope"]
+                )
+                row["write_latency_comparable_to_baseline"] = write_latency_comparable
                 row["delta_vs_baseline"] = {
                     "throughput_pct": compute_relative_delta(
                         metrics["throughput_ops_per_sec"],
@@ -381,8 +414,13 @@ def build_pr14_6_operational_report(
                     ),
                     "read_p95_ms": metrics["read_p95_ms"]
                     - baseline_metrics["read_p95_ms"],
-                    "write_p95_ms": metrics["write_p95_ms"]
-                    - baseline_metrics["write_p95_ms"],
+                    "write_p95_ms": (
+                        metrics["write_p95_ms"] - baseline_metrics["write_p95_ms"]
+                        if write_latency_comparable
+                        else None
+                    ),
+                    "final_flush_ms": metrics["final_flush_ms"]
+                    - baseline_metrics["final_flush_ms"],
                 }
             family_rows.append(row)
 
@@ -448,18 +486,24 @@ def render_pr14_6_operational_summary(report: dict[str, Any]) -> str:
         lines.append(f"## {labels[family]}")
         for row in rows:
             delta = row["delta_vs_baseline"]
+            if delta["write_p95_ms"] is None:
+                write_delta = "write p95=n/a (scope mismatch)"
+            else:
+                write_delta = f"write p95={delta['write_p95_ms']:+.2f} ms"
             lines.extend(
                 [
                     f"- {row['description']}",
                     (
                         f"  nodes={row['nodes']}, workers={row['workers']}, "
                         f"wal={row['wal_flush_policy']}, throughput={row['throughput_ops_per_sec']:.2f} ops/s, "
-                        f"read p95={row['read_p95_ms']:.2f} ms, write p95={row['write_p95_ms']:.2f} ms"
+                        f"read p95={row['read_p95_ms']:.2f} ms, "
+                        f"write p95={row['write_p95_ms']:.2f} ms ({row['write_latency_scope']}), "
+                        f"final flush={row['final_flush_ms']:.2f} ms"
                     ),
                     (
                         f"  vs baseline: throughput={delta['throughput_pct']:+.2f}%, "
                         f"read p95={delta['read_p95_ms']:+.2f} ms, "
-                        f"write p95={delta['write_p95_ms']:+.2f} ms"
+                        f"{write_delta}, final flush={delta['final_flush_ms']:+.2f} ms"
                     ),
                 ]
             )
@@ -529,6 +573,7 @@ def run_suite(profile: SuiteProfile, repo_root: Path, results_dir: Path) -> dict
             **profile.operational_env,
             "ALAYASIKI_BENCH_RESULTS_PATH": str(operational_result),
         },
+        cleared_env_prefixes=("ALAYASIKI_BENCH_",),
     )
     run_command(
         "graphrag production",
@@ -538,6 +583,7 @@ def run_suite(profile: SuiteProfile, repo_root: Path, results_dir: Path) -> dict
             **profile.graphrag_env,
             "ALAYASIKI_GRAPHRAG_RESULTS_PATH": str(graphrag_result),
         },
+        cleared_env_prefixes=("ALAYASIKI_GRAPHRAG_",),
     )
     run_command(
         "python ann benchmark",

--- a/benchmarks/results/operational_latency_pr14_6_write_batch.json
+++ b/benchmarks/results/operational_latency_pr14_6_write_batch.json
@@ -1,6 +1,6 @@
 {
   "benchmark": "operational_latency_bench",
-  "generated_at_unix": 1773146822,
+  "generated_at_unix": 1773235991,
   "config": {
     "nodes": 4000,
     "workers": 6,
@@ -8,29 +8,34 @@
     "write_every": 10,
     "read_to_write_ratio": "9:1",
     "wal_flush_policy": "always",
-    "seed_wal_flush_policy": "batch:1024"
+    "seed_wal_flush_policy": "batch:1024",
+    "write_latency_scope": "durable"
   },
   "totals": {
-    "elapsed_sec": 0.654029208,
+    "elapsed_sec": 0.791351792,
     "total_ops": 600,
     "read_ops": 540,
     "write_ops": 60,
-    "throughput_ops_per_sec": 917.3902215082725
+    "throughput_ops_per_sec": 758.1962991245744
   },
   "read_latency_ns": {
-    "p50_ns": 4827042,
-    "p95_ns": 11764291,
-    "p99_ns": 15321125,
-    "p50_ms": 4.827042,
-    "p95_ms": 11.764291,
-    "p99_ms": 15.321125
+    "p50_ns": 5748750,
+    "p95_ns": 16409917,
+    "p99_ns": 24585792,
+    "p50_ms": 5.74875,
+    "p95_ms": 16.409917,
+    "p99_ms": 24.585792
   },
   "write_latency_ns": {
-    "p50_ns": 10184042,
-    "p95_ns": 69400708,
-    "p99_ns": 87256750,
-    "p50_ms": 10.184042,
-    "p95_ms": 69.400708,
-    "p99_ms": 87.25675
+    "p50_ns": 10055000,
+    "p95_ns": 72831125,
+    "p99_ns": 86021541,
+    "p50_ms": 10.055,
+    "p95_ms": 72.831125,
+    "p99_ms": 86.021541
+  },
+  "durability_barrier": {
+    "final_flush_ns": 20875,
+    "final_flush_ms": 0.020875
   }
 }

--- a/benchmarks/tests/test_benchmark_suite.py
+++ b/benchmarks/tests/test_benchmark_suite.py
@@ -117,10 +117,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "always",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "durable",
                     },
                     "totals": {"throughput_ops_per_sec": 100.0},
                     "read_latency_ns": {"p95_ms": 20.0, "p99_ms": 25.0},
                     "write_latency_ns": {"p95_ms": 120.0, "p99_ms": 140.0},
+                    "durability_barrier": {"final_flush_ms": 2.0},
                 },
                 "flush_interval_15ms": {
                     "config": {
@@ -131,10 +133,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "interval:15ms",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 130.0},
                     "read_latency_ns": {"p95_ms": 22.0, "p99_ms": 28.0},
                     "write_latency_ns": {"p95_ms": 90.0, "p99_ms": 100.0},
+                    "durability_barrier": {"final_flush_ms": 12.0},
                 },
                 "flush_batch_32": {
                     "config": {
@@ -145,10 +149,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 160.0},
                     "read_latency_ns": {"p95_ms": 21.0, "p99_ms": 24.0},
                     "write_latency_ns": {"p95_ms": 70.0, "p99_ms": 85.0},
+                    "durability_barrier": {"final_flush_ms": 18.0},
                 },
                 "scale_100k_nodes": {
                     "config": {
@@ -159,10 +165,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 150.0},
                     "read_latency_ns": {"p95_ms": 18.0, "p99_ms": 21.0},
                     "write_latency_ns": {"p95_ms": 75.0, "p99_ms": 82.0},
+                    "durability_barrier": {"final_flush_ms": 20.0},
                 },
                 "scale_1m_nodes": {
                     "config": {
@@ -173,10 +181,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:4096",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 120.0},
                     "read_latency_ns": {"p95_ms": 28.0, "p99_ms": 33.0},
                     "write_latency_ns": {"p95_ms": 95.0, "p99_ms": 104.0},
+                    "durability_barrier": {"final_flush_ms": 45.0},
                 },
                 "workers_8": {
                     "config": {
@@ -187,10 +197,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 140.0},
                     "read_latency_ns": {"p95_ms": 19.0, "p99_ms": 22.0},
                     "write_latency_ns": {"p95_ms": 78.0, "p99_ms": 86.0},
+                    "durability_barrier": {"final_flush_ms": 16.0},
                 },
                 "workers_32": {
                     "config": {
@@ -201,10 +213,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 260.0},
                     "read_latency_ns": {"p95_ms": 26.0, "p99_ms": 31.0},
                     "write_latency_ns": {"p95_ms": 92.0, "p99_ms": 105.0},
+                    "durability_barrier": {"final_flush_ms": 24.0},
                 },
                 "workers_128": {
                     "config": {
@@ -215,10 +229,12 @@ class BenchmarkSuiteTests(unittest.TestCase):
                         "read_to_write_ratio": "9:1",
                         "wal_flush_policy": "batch:32",
                         "seed_wal_flush_policy": "batch:2048",
+                        "write_latency_scope": "submit_only",
                     },
                     "totals": {"throughput_ops_per_sec": 210.0},
                     "read_latency_ns": {"p95_ms": 41.0, "p99_ms": 48.0},
                     "write_latency_ns": {"p95_ms": 130.0, "p99_ms": 144.0},
+                    "durability_barrier": {"final_flush_ms": 55.0},
                 },
             }
 
@@ -237,14 +253,19 @@ class BenchmarkSuiteTests(unittest.TestCase):
             self.assertAlmostEqual(
                 flush_rows[1]["delta_vs_baseline"]["throughput_pct"], 30.0
             )
+            self.assertFalse(flush_rows[2]["write_latency_comparable_to_baseline"])
+            self.assertIsNone(flush_rows[2]["delta_vs_baseline"]["write_p95_ms"])
             self.assertAlmostEqual(
-                flush_rows[2]["delta_vs_baseline"]["write_p95_ms"], -50.0
+                flush_rows[2]["delta_vs_baseline"]["final_flush_ms"], 16.0
             )
 
             scale_rows = report["scenario_groups"]["scale"]
             self.assertEqual(scale_rows[1]["nodes"], 1_000_000)
             self.assertAlmostEqual(
                 scale_rows[1]["delta_vs_baseline"]["read_p95_ms"], 10.0
+            )
+            self.assertAlmostEqual(
+                scale_rows[1]["delta_vs_baseline"]["write_p95_ms"], 20.0
             )
 
             worker_rows = report["scenario_groups"]["workers"]
@@ -261,6 +282,35 @@ class BenchmarkSuiteTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "flush_always"):
                 benchmark_suite.build_pr14_6_operational_report(
                     scenario_groups, results_dir
+                )
+
+    def test_build_pr14_6_operational_report_rejects_missing_latency(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            results_dir = Path(tmp)
+            scenario = benchmark_suite.build_pr14_6_operational_scenarios()["flush_policy"][0]
+            (results_dir / f"pr14_6_operational_{scenario.slug}.json").write_text(
+                benchmark_suite.json.dumps(
+                    {
+                        "config": {
+                            "nodes": 100000,
+                            "workers": 8,
+                            "ops_per_worker": 40,
+                            "write_every": 10,
+                            "read_to_write_ratio": "9:1",
+                            "wal_flush_policy": "always",
+                            "seed_wal_flush_policy": "batch:2048",
+                            "write_latency_scope": "durable",
+                        },
+                        "totals": {"throughput_ops_per_sec": 100.0},
+                        "durability_barrier": {"final_flush_ms": 2.0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "latency=read_p95_ms"):
+                benchmark_suite.build_pr14_6_operational_report(
+                    {"flush_policy": [scenario]}, results_dir
                 )
 
     def test_run_operational_scenario_clears_ambient_bench_env(self) -> None:
@@ -292,6 +342,32 @@ class BenchmarkSuiteTests(unittest.TestCase):
                 env["ALAYASIKI_BENCH_RESULTS_PATH"],
                 str(results_dir / "pr14_6_operational_flush_always.json"),
             )
+
+    def test_run_suite_clears_ambient_profile_env(self) -> None:
+        profile = benchmark_suite.build_profile("baseline")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            results_dir = repo_root / "results"
+            with mock.patch.dict(
+                benchmark_suite.os.environ,
+                {
+                    "ALAYASIKI_BENCH_WAL_FLUSH_POLICY": "batch",
+                    "ALAYASIKI_BENCH_STRAY": "stale",
+                    "ALAYASIKI_GRAPHRAG_STRAY": "stale",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(benchmark_suite.subprocess, "run") as run_mock:
+                    benchmark_suite.run_suite(profile, repo_root, results_dir)
+
+            operational_env = run_mock.call_args_list[0].kwargs["env"]
+            graphrag_env = run_mock.call_args_list[1].kwargs["env"]
+            self.assertNotIn("ALAYASIKI_BENCH_WAL_FLUSH_POLICY", operational_env)
+            self.assertNotIn("ALAYASIKI_BENCH_STRAY", operational_env)
+            self.assertEqual(operational_env["ALAYASIKI_BENCH_NODES"], "4000")
+            self.assertNotIn("ALAYASIKI_GRAPHRAG_STRAY", graphrag_env)
+            self.assertEqual(graphrag_env["ALAYASIKI_GRAPHRAG_SEED_NODES"], "4000")
 
 
 if __name__ == "__main__":

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -356,7 +356,7 @@
 - `prototypes/benches/operational_latency_bench.rs` は `ALAYASIKI_BENCH_WAL_FLUSH_POLICY`（`always` / `interval` / `batch`）と seed 用 batch flush を受け付けるよう拡張し、WAL flush 方針比較と大規模 seed を同じベンチで扱えるようにした
 - `benchmarks/benchmark_suite.py --mode pr14-6-operational` を追加し、WAL flush 比較・`10^5 -> 10^6` ノード scale sweep・`8/32/128` worker sweep を `benchmarks/results/pr14_6_operational_*.json` と `pr14_6_operational_matrix.{json,md}` に保存できるようにした
 - ingest 永続化を `Repository::persist_ingest_batch` に集約し、複数チャンク文書でも node 書き込み + idempotency 記録を 1 WAL transaction にまとめるよう変更
-- baseline 条件 (`nodes=4000, workers=6, ops_per_worker=100, write_every=10`) の再計測結果を `benchmarks/results/operational_latency_pr14_6_write_batch.json` に保存し、既存 baseline 比で throughput `389.38 -> 917.39 ops/s`、read p95 `16.96 -> 11.76 ms`、write p95 `188.67 -> 69.40 ms` を確認
+- baseline 条件 (`nodes=4000, workers=6, ops_per_worker=100, write_every=10`) の再計測結果を `benchmarks/results/operational_latency_pr14_6_write_batch.json` に保存し、既存 baseline 比で throughput `389.38 -> 758.20 ops/s`、read p95 `16.96 -> 16.41 ms`、write p95 `188.67 -> 72.83 ms` を確認
 - 長時間の実ベンチ結果はこの変更では未同梱。上記 runner を実行して成果物を生成し、閾値/採用 flush policy を確定した時点でチェックボックスを更新する
 
 ---

--- a/ingestion/src/processor.rs
+++ b/ingestion/src/processor.rs
@@ -372,6 +372,9 @@ impl IngestionPipeline {
                 .await?;
 
             if let Some(queue) = &self.job_queue {
+                // Queue provenance should point at a durable snapshot that already includes
+                // the ingest batch, even when WAL writes are buffered.
+                self.repo.flush().await?;
                 let snapshot_id = self.repo.current_snapshot_id().await;
                 for (chunk_id, chunk_content) in queued_extractions {
                     let job = Job::ExtractEntities {

--- a/ingestion/tests/ingestion_test.rs
+++ b/ingestion/tests/ingestion_test.rs
@@ -6,7 +6,7 @@ use ingestion::processor::IngestionPipeline;
 use std::collections::HashMap;
 use std::sync::Arc;
 use storage::repo::Repository;
-use storage::wal::Wal;
+use storage::wal::{Wal, WalFlushPolicy, WalOptions};
 use tempfile::tempdir;
 use tokio::sync::Mutex;
 
@@ -316,6 +316,51 @@ async fn test_ingestion_enqueues_fixed_model_and_snapshot_for_reproducibility() 
             assert!(snapshot_id.starts_with("wal-lsn-"));
         }
     }
+}
+
+#[tokio::test]
+async fn test_ingestion_flushes_buffered_wal_before_enqueuing_snapshot() {
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("repro_buffered.wal");
+    let repo = Arc::new(
+        Repository::open_with_options(
+            &wal_path,
+            WalOptions {
+                flush_policy: WalFlushPolicy::Batch { max_entries: 16 },
+                ..WalOptions::default()
+            },
+        )
+        .await
+        .unwrap(),
+    );
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let queue = Arc::new(CapturingQueue {
+        jobs: captured.clone(),
+    });
+
+    let mut pipeline = IngestionPipeline::new(repo.clone());
+    pipeline.set_job_queue(queue);
+
+    let request = IngestionRequest::Text {
+        content: "Graph database query".to_string(),
+        metadata: HashMap::new(),
+        idempotency_key: None,
+        model_id: Some("triplex-lite@1.0.0".to_string()),
+    };
+
+    pipeline.ingest(request).await.unwrap();
+
+    let jobs = captured.lock().await;
+    assert!(!jobs.is_empty());
+    match &jobs[0] {
+        jobs::queue::Job::ExtractEntities { snapshot_id, .. } => {
+            assert_eq!(snapshot_id, "wal-lsn-1");
+        }
+    }
+    drop(jobs);
+
+    assert_eq!(repo.current_snapshot_id().await, "wal-lsn-1");
 }
 
 struct FailingExtractor;

--- a/prototypes/benches/operational_latency_bench.rs
+++ b/prototypes/benches/operational_latency_bench.rs
@@ -28,6 +28,7 @@ struct OperationalBenchmarkReport {
     totals: Totals,
     read_latency_ns: LatencySummary,
     write_latency_ns: LatencySummary,
+    durability_barrier: DurabilityBarrier,
 }
 
 #[derive(Debug, Serialize)]
@@ -39,6 +40,7 @@ struct ReportConfig {
     read_to_write_ratio: String,
     wal_flush_policy: String,
     seed_wal_flush_policy: String,
+    write_latency_scope: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -48,6 +50,12 @@ struct Totals {
     read_ops: usize,
     write_ops: usize,
     throughput_ops_per_sec: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct DurabilityBarrier {
+    final_flush_ns: u128,
+    final_flush_ms: f64,
 }
 
 fn env_usize(key: &str, default: usize) -> usize {
@@ -107,6 +115,13 @@ fn format_wal_flush_policy(policy: WalFlushPolicy) -> String {
         WalFlushPolicy::Always => "always".to_string(),
         WalFlushPolicy::Interval(interval) => format!("interval:{}ms", interval.as_millis()),
         WalFlushPolicy::Batch { max_entries } => format!("batch:{max_entries}"),
+    }
+}
+
+fn write_latency_scope(policy: WalFlushPolicy) -> &'static str {
+    match policy {
+        WalFlushPolicy::Always => "durable",
+        WalFlushPolicy::Interval(_) | WalFlushPolicy::Batch { .. } => "submit_only",
     }
 }
 
@@ -263,9 +278,10 @@ async fn main() {
         handle.await.unwrap();
     }
 
-    // Buffered WAL policies need an explicit final flush so the scenario only
-    // completes after all measured writes reach durable storage.
+    // Buffered WAL policies defer some fsync cost to a final durability barrier.
+    let final_flush_start = Instant::now();
     repo.flush().await.unwrap();
+    let final_flush_ns = final_flush_start.elapsed().as_nanos();
     let total_elapsed = scenario_start.elapsed();
     let read_samples = read_latencies.lock().await.clone();
     let write_samples = write_latencies.lock().await.clone();
@@ -289,6 +305,7 @@ async fn main() {
             read_to_write_ratio: format!("{}:1", write_every.saturating_sub(1)),
             wal_flush_policy: format_wal_flush_policy(wal_flush_policy),
             seed_wal_flush_policy: format_wal_flush_policy(seed_wal_flush_policy),
+            write_latency_scope: write_latency_scope(wal_flush_policy).to_string(),
         },
         totals: Totals {
             elapsed_sec: total_elapsed.as_secs_f64(),
@@ -299,13 +316,17 @@ async fn main() {
         },
         read_latency_ns: read_summary,
         write_latency_ns: write_summary,
+        durability_barrier: DurabilityBarrier {
+            final_flush_ns,
+            final_flush_ms: final_flush_ns as f64 / 1_000_000.0,
+        },
     };
 
     write_json_report(&results_path, &report);
 
     println!("=== Operational Latency Benchmark (Query + Ingestion) ===");
     println!(
-        "config: nodes={}, workers={}, ops_per_worker={}, write_every={} (read:write ~= {}:{}), wal_flush_policy={}, seed_wal_flush_policy={}",
+        "config: nodes={}, workers={}, ops_per_worker={}, write_every={} (read:write ~= {}:{}), wal_flush_policy={}, seed_wal_flush_policy={}, write_latency_scope={}",
         node_count,
         workers,
         ops_per_worker,
@@ -313,7 +334,8 @@ async fn main() {
         write_every - 1,
         1,
         report.config.wal_flush_policy,
-        report.config.seed_wal_flush_policy
+        report.config.seed_wal_flush_policy,
+        report.config.write_latency_scope,
     );
     println!(
         "workload: total_ops={}, read_ops={}, write_ops={}, elapsed={:.3}s, throughput={:.2} ops/s",
@@ -335,6 +357,10 @@ async fn main() {
         format_ns(report.write_latency_ns.p50_ns),
         format_ns(report.write_latency_ns.p95_ns),
         format_ns(report.write_latency_ns.p99_ns)
+    );
+    println!(
+        "durability barrier: final_flush={}",
+        format_ns(report.durability_barrier.final_flush_ns)
     );
 
     let read_p95_ms = report.read_latency_ns.p95_ms;

--- a/storage/src/repo.rs
+++ b/storage/src/repo.rs
@@ -722,13 +722,23 @@ impl Repository {
             .collect();
         self.validate_index_transaction(&node_mutations).await?;
 
+        let mut idempotency_index = self.idempotency_index.write().await;
+        let new_idempotency_records: Vec<(String, Vec<u64>)> = idempotency_records
+            .into_iter()
+            .filter(|(key, _)| !idempotency_index.contains_key(key))
+            .collect();
+
         let mut tx_operations = mutations_to_tx_operations(&node_mutations);
-        tx_operations.extend(idempotency_records.iter().map(|(key, node_ids)| {
+        tx_operations.extend(new_idempotency_records.iter().map(|(key, node_ids)| {
             TxOperation::RecordIdempotency {
                 key: key.clone(),
                 node_ids: node_ids.clone(),
             }
         }));
+
+        if tx_operations.is_empty() {
+            return Ok(());
+        }
 
         let tx_entry = WalEntry::Transaction(tx_operations.clone());
         let tx_bytes = serialize_wal_entry(&tx_entry)?;
@@ -740,7 +750,6 @@ impl Repository {
 
         let mut nodes = self.nodes.write().await;
         let mut index = self.hyper_index.write().await;
-        let mut idempotency_index = self.idempotency_index.write().await;
         let mut edge_meta = self.edge_metadata.write().await;
 
         for operation in &tx_operations {
@@ -1193,7 +1202,7 @@ fn apply_replayed_entry(
             edge_meta.retain(|(src, tgt, _), _| *src != *id && *tgt != *id);
         }
         WalEntry::IdempotencyKey { key, node_ids } => {
-            idem_map.insert(key.clone(), node_ids.clone());
+            record_idempotency_if_absent(idem_map, key, node_ids);
         }
         WalEntry::Transaction(operations) => {
             for operation in operations {
@@ -1201,6 +1210,16 @@ fn apply_replayed_entry(
             }
         }
     }
+}
+
+fn record_idempotency_if_absent(
+    idem_map: &mut HashMap<String, Vec<u64>>,
+    key: &str,
+    node_ids: &[u64],
+) {
+    idem_map
+        .entry(key.to_string())
+        .or_insert_with(|| node_ids.to_vec());
 }
 
 fn apply_tx_operation(
@@ -1232,7 +1251,7 @@ fn apply_tx_operation(
             edge_meta.retain(|(src, tgt, _), _| *src != *id && *tgt != *id);
         }
         TxOperation::RecordIdempotency { key, node_ids } => {
-            idem_map.insert(key.clone(), node_ids.clone());
+            record_idempotency_if_absent(idem_map, key, node_ids);
         }
     }
 }
@@ -1508,6 +1527,55 @@ mod tests {
 
         assert_eq!(record_count, 1);
         assert_eq!(tx_mutation_count, 4);
+    }
+
+    #[tokio::test]
+    async fn test_persist_ingest_batch_keeps_first_content_hash_mapping() {
+        let dir = tempdir().unwrap();
+        let wal_path = dir.path().join("ingest_batch_first_writer.wal");
+        let repo = Repository::open(&wal_path).await.unwrap();
+
+        repo.persist_ingest_batch(
+            vec![Node::new(11, vec![1.0], "first".to_string())],
+            vec![
+                ("content-hash".to_string(), vec![11]),
+                ("request-a".to_string(), vec![11]),
+            ],
+        )
+        .await
+        .unwrap();
+
+        repo.persist_ingest_batch(
+            vec![
+                Node::new(11, vec![1.0], "first".to_string()),
+                Node::new(12, vec![2.0], "second".to_string()),
+            ],
+            vec![
+                ("content-hash".to_string(), vec![11, 12]),
+                ("request-b".to_string(), vec![11, 12]),
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(repo.check_idempotency("content-hash").await, Some(vec![11]));
+        assert_eq!(repo.check_idempotency("request-a").await, Some(vec![11]));
+        assert_eq!(
+            repo.check_idempotency("request-b").await,
+            Some(vec![11, 12])
+        );
+
+        drop(repo);
+
+        let reopened = Repository::open(&wal_path).await.unwrap();
+        assert_eq!(
+            reopened.check_idempotency("content-hash").await,
+            Some(vec![11])
+        );
+        assert_eq!(
+            reopened.check_idempotency("request-b").await,
+            Some(vec![11, 12])
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Purpose
- Complete the PR-14.6 write-latency improvement task by reducing WAL appends on the ingest path.
- Address review findings around idempotency correctness, durable snapshot provenance, and benchmark reproducibility/reporting.

## What Changed
- Added first-writer preservation to `Repository::persist_ingest_batch` so duplicate idempotency keys no longer overwrite existing mappings.
- Flushed buffered WAL before enqueueing extraction jobs so queued provenance uses a durable `snapshot_id`.
- Hardened `benchmarks/benchmark_suite.py` to clear ambient benchmark env in suite mode and fail fast on incomplete operational artifacts.
- Extended `operational_latency_bench` reports with `write_latency_scope` and `durability_barrier.final_flush_*` so buffered flush policies are not reported as if they were per-write durable latency.
- Added regression tests for the above behavior and refreshed the baseline operational benchmark artifact.

## Benchmark Result
- Baseline condition: `nodes=4000`, `workers=6`, `ops_per_worker=100`, `write_every=10`
- Throughput: `389.38 -> 758.20 ops/s`
- Read p95: `16.96 -> 16.41 ms`
- Write p95: `188.67 -> 72.83 ms`
- Durability barrier: `0.020875 ms`
- Artifact: `benchmarks/results/operational_latency_pr14_6_write_batch.json`

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p storage -p ingestion -p prototypes --all-targets -- -D warnings`
- `python3 -m unittest benchmarks/tests/test_benchmark_suite.py`
- `cargo test --workspace`
- `cargo bench -p prototypes --bench operational_latency_bench` (baseline env, artifact saved)

## Exit Criteria
- [x] Write latency improvement measured and documented
- [ ] Scale sweep (`10^5 -> 10^6`) still pending
- [ ] Worker sweep (`8/32/128`) still pending
