### PR TITLE
[PR-14.8] 環境整備とビルド安定化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,12 @@ on:
 
 jobs:
   rust-quality:
-    name: Rust Quality (fmt + clippy)
-    runs-on: ubuntu-latest
+    name: Rust Quality (fmt + clippy, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -20,9 +24,27 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  rust-build:
+    name: Rust Build (workspace, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo build
+        run: cargo build --workspace
+
   rust-tests:
-    name: Rust Tests (workspace)
-    runs-on: ubuntu-latest
+    name: Rust Tests (workspace, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -398,13 +398,19 @@
 
 * Depends on: PR-14.7
 
-- [ ] **macOS (Mシリーズ) ビルド失敗の解消**: `usearch`/`cxx` 依存による arm64 クロスコンパイル失敗を修正 (Issue #47)
+- [x] **macOS (Mシリーズ) ビルド失敗の解消**: `usearch`/`cxx` 依存による arm64 クロスコンパイル失敗を修正 (Issue #47)
 - [ ] **マルチプラットフォームCIの安定化**: macOS (arm64) / Linux (x86_64) の両環境でテストが通過することをCIで保証
-- [ ] **開発サイクルの正常化**: ローカル開発環境での `cargo build` / `cargo test --workspace` が追加設定なしで完了すること
+- [x] **開発サイクルの正常化**: ローカル開発環境での `cargo build` / `cargo test --workspace` が追加設定なしで完了すること
 
 **Done Criteria:**
 - [ ] `cargo test --workspace` が macOS (Apple Silicon) と Linux で追加設定なし通過
 - [ ] CI の `build` / `test` ジョブが両プラットフォームでグリーン
+
+**Notes:**
+- `storage` の `usearch` 依存を `cfg(not(target_os = "macos"))` へ移し、macOS では `HnswIndex` API を保ったまま `LinearAnnIndex` ベースのフォールバックを使うことで `cxx` / Apple SDK ヘッダ欠落によるビルド失敗を回避する方針に切り替えた
+- `.github/workflows/ci.yml` に `rust-build` と macOS 行列の `rust-quality` / `rust-tests` を追加し、Linux と macOS の両方で build/test を常時検証できるようにした
+- 前回観測していた `alayasiki-core` の「停止」はハングではなく初回 `test` コンパイルの長時間化だった。途中中断で壊れた `target/debug/incremental` を `cargo clean` で再生成した後、ローカル Apple Silicon で `cargo test --workspace -j 1` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --all -- --check` の通過を確認した
+- macOS フォールバックは `usearch` 実装と同じ契約になるよう調整し、空 embedding の upsert を delete として扱うこと、次元不一致 insert をスキップすること、最後の削除後に `dim` をリセットすることを `storage` のユニットテストで確認した
 
 ---
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -18,4 +18,6 @@ crc32fast = "1.3"
 bytes = "1.0"
 tracing = "0.1"
 tempfile = "3.3"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 usearch = { version = "2", optional = true }

--- a/storage/src/index/hnsw.rs
+++ b/storage/src/index/hnsw.rs
@@ -1,5 +1,7 @@
-use super::ann::{LinearAnnIndex, VectorIndex};
+use super::ann::VectorIndex;
 
+#[cfg(target_os = "macos")]
+use super::ann::LinearAnnIndex;
 #[cfg(not(target_os = "macos"))]
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
@@ -145,6 +147,14 @@ impl HnswIndex {
             dim: None,
         }
     }
+
+    fn remove_existing(&mut self, id: u64) -> bool {
+        let deleted = self.inner.delete(id);
+        if self.inner.is_empty() {
+            self.dim = None;
+        }
+        deleted
+    }
 }
 
 impl Default for HnswIndex {
@@ -233,9 +243,11 @@ impl VectorIndex for HnswIndex {
 impl VectorIndex for HnswIndex {
     fn insert(&mut self, id: u64, embedding: &[f32]) {
         if embedding.is_empty() {
-            self.delete(id);
+            self.remove_existing(id);
             return;
         }
+
+        self.remove_existing(id);
 
         if let Some(expected_dim) = self.dim {
             if expected_dim != embedding.len() {
@@ -255,11 +267,7 @@ impl VectorIndex for HnswIndex {
     }
 
     fn delete(&mut self, id: u64) -> bool {
-        let deleted = self.inner.delete(id);
-        if self.inner.is_empty() {
-            self.dim = None;
-        }
-        deleted
+        self.remove_existing(id)
     }
 
     fn search(&self, query: &[f32], k: usize) -> Vec<(u64, f32)> {
@@ -351,6 +359,34 @@ mod tests {
         assert_eq!(index.len(), 1);
         let results = index.search(&[1.0, 0.0], 5);
         assert!(results.iter().all(|(id, _)| *id != 1));
+    }
+
+    #[test]
+    fn test_hnsw_dim_mismatch_upsert_drops_existing_vector_when_index_stays_non_empty() {
+        let mut index = HnswIndex::new();
+        index.insert(1, &[1.0_f32, 0.0]);
+        index.insert(2, &[0.0, 1.0]);
+
+        index.insert(1, &[1.0_f32, 0.0, 0.0]);
+
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.dim(), Some(2));
+        let results = index.search(&[1.0, 0.0], 5);
+        assert!(results.iter().all(|(id, _)| *id != 1));
+        assert!(results.iter().any(|(id, _)| *id == 2));
+    }
+
+    #[test]
+    fn test_hnsw_dim_mismatch_upsert_replaces_last_vector_with_new_dimension() {
+        let mut index = HnswIndex::new();
+        index.insert(1, &[1.0_f32, 0.0]);
+
+        index.insert(1, &[1.0_f32, 0.0, 0.0]);
+
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.dim(), Some(3));
+        let results = index.search(&[1.0, 0.0, 0.0], 1);
+        assert_eq!(results[0].0, 1);
     }
 
     #[test]

--- a/storage/src/index/hnsw.rs
+++ b/storage/src/index/hnsw.rs
@@ -1,22 +1,28 @@
+use super::ann::{LinearAnnIndex, VectorIndex};
+
+#[cfg(not(target_os = "macos"))]
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
+
+#[cfg(not(target_os = "macos"))]
 /// HNSW-based ANN index backed by the `usearch` C++ library.
 ///
 /// # Lazy initialisation
 /// The underlying `usearch::Index` requires the vector dimension at creation
-/// time.  `HnswIndex` delays creation until the first `insert` call so that
+/// time. `HnswIndex` delays creation until the first `insert` call so that
 /// callers do not need to know the dimension up-front (matching the
-/// `LinearAnnIndex` interface).  Any subsequent `insert` with a mismatched
+/// `LinearAnnIndex` interface). Any subsequent `insert` with a mismatched
 /// dimension is silently ignored (same behaviour as `cosine_similarity`).
 ///
 /// # Thread safety
 /// `usearch::Index` wraps a C++ object via a raw pointer and therefore does
-/// not derive `Send`/`Sync` automatically.  The underlying USearch library is
+/// not derive `Send`/`Sync` automatically. The underlying USearch library is
 /// documented as thread-safe for concurrent reads; exclusive write access is
-/// enforced at the `HyperIndex` level by an `RwLock`.  The `unsafe` impls
+/// enforced at the `HyperIndex` level by an `RwLock`. The `unsafe` impls
 /// below are therefore sound.
 ///
 /// # ANN Sidecar Snapshot Format (future work)
 /// To support fast cold-start without a full WAL replay, the HNSW graph can be
-/// serialised alongside a regular storage snapshot.  Planned format:
+/// serialised alongside a regular storage snapshot. Planned format:
 ///
 /// ```text
 /// <snapshot_dir>/ann_sidecar.usearch   – native usearch binary dump
@@ -27,13 +33,9 @@
 /// ```
 ///
 /// On startup the engine checks whether the sidecar's `lsn` matches the
-/// snapshot LSN.  If so, the index is loaded directly; otherwise the index is
-/// rebuilt from the WAL replay as today.  This is tracked as a follow-up task
+/// snapshot LSN. If so, the index is loaded directly; otherwise the index is
+/// rebuilt from the WAL replay as today. This is tracked as a follow-up task
 /// in `docs/PLAN.md`.
-use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
-
-use super::ann::VectorIndex;
-
 pub struct HnswIndex {
     /// Lazily-initialised inner index (None until first insert).
     inner: Option<Index>,
@@ -43,11 +45,22 @@ pub struct HnswIndex {
     count: usize,
 }
 
+#[cfg(target_os = "macos")]
+/// macOS fallback that preserves the HNSW API while avoiding the `usearch`
+/// C++ toolchain dependency on Apple Silicon developer machines.
+pub struct HnswIndex {
+    inner: LinearAnnIndex,
+    dim: Option<usize>,
+}
+
+#[cfg(not(target_os = "macos"))]
 // SAFETY: USearch C++ implementation is thread-safe for concurrent reads.
 // Mutable operations are serialised by the RwLock on HyperIndex.
 unsafe impl Send for HnswIndex {}
+#[cfg(not(target_os = "macos"))]
 unsafe impl Sync for HnswIndex {}
 
+#[cfg(not(target_os = "macos"))]
 impl HnswIndex {
     pub fn new() -> Self {
         Self {
@@ -124,12 +137,23 @@ impl HnswIndex {
     }
 }
 
+#[cfg(target_os = "macos")]
+impl HnswIndex {
+    pub fn new() -> Self {
+        Self {
+            inner: LinearAnnIndex::new(),
+            dim: None,
+        }
+    }
+}
+
 impl Default for HnswIndex {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 impl VectorIndex for HnswIndex {
     fn insert(&mut self, id: u64, embedding: &[f32]) {
         if embedding.is_empty() {
@@ -176,9 +200,6 @@ impl VectorIndex for HnswIndex {
         }
         match idx.search(query, count) {
             Ok(matches) => {
-                // usearch cosine metric returns angular distance = 1 - cosine_similarity.
-                // Convert back to similarity score (higher = more similar) and
-                // sort descending for a stable top-k.
                 let mut results: Vec<(u64, f32)> = matches
                     .keys
                     .into_iter()
@@ -205,6 +226,52 @@ impl VectorIndex for HnswIndex {
         } else {
             self.dim
         }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl VectorIndex for HnswIndex {
+    fn insert(&mut self, id: u64, embedding: &[f32]) {
+        if embedding.is_empty() {
+            self.delete(id);
+            return;
+        }
+
+        if let Some(expected_dim) = self.dim {
+            if expected_dim != embedding.len() {
+                tracing::warn!(
+                    "HnswIndex::insert: dimension mismatch (expected {:?}, got {}), skipping id={}",
+                    self.dim,
+                    embedding.len(),
+                    id
+                );
+                return;
+            }
+        } else {
+            self.dim = Some(embedding.len());
+        }
+
+        self.inner.insert(id, embedding);
+    }
+
+    fn delete(&mut self, id: u64) -> bool {
+        let deleted = self.inner.delete(id);
+        if self.inner.is_empty() {
+            self.dim = None;
+        }
+        deleted
+    }
+
+    fn search(&self, query: &[f32], k: usize) -> Vec<(u64, f32)> {
+        self.inner.search(query, k)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn dim(&self) -> Option<usize> {
+        self.dim
     }
 }
 


### PR DESCRIPTION
## Purpose
- fix Apple Silicon local build failures caused by the `usearch` / `cxx` toolchain path
- preserve the `HnswIndex` API on macOS via a linear fallback with matching semantics
- add macOS/Linux build-test coverage in CI for PR-14.8

## Key Design Decisions
- move `usearch` behind `cfg(not(target_os = "macos"))` so macOS no longer compiles the C++ dependency path
- keep `HnswIndex` available on macOS, but back it with `LinearAnnIndex` and preserve the same insert/delete/dimension contracts as the Linux `usearch` implementation
- add `rust-build` plus macOS matrix entries for `rust-quality` and `rust-tests` in GitHub Actions
- document local verification and remaining CI-only confirmation in `docs/PLAN.md`

## Exit Criteria
- [x] macOS (M-series) build failure caused by `usearch` / `cxx` is resolved locally
- [ ] macOS/Linux CI build and test jobs are green on GitHub Actions
- [x] local `cargo build` / `cargo test --workspace` workflow works without extra settings

## Commands Executed
- `cargo test -p alayasiki-core --no-run -j 1 -vv`
- `cargo clean`
- `cargo test -p storage --lib index::hnsw::tests::test_hnsw_dim_mismatch_ignored -- --nocapture`
- `cargo test -p storage --lib index::hnsw::tests::test_hnsw_empty_upsert_removes_existing_vector -- --nocapture`
- `cargo test --workspace -j 1`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Observed Results
- `cargo test --workspace -j 1` passed on local Apple Silicon after clearing a corrupted incremental cache caused by interrupted earlier runs
- the macOS fallback initially broke two `storage::index::hnsw` unit tests; those were fixed by matching the original HNSW semantics for empty-vector delete and dimension-mismatch skip
- CI coverage was expanded, but GitHub Actions results remain to be confirmed after PR creation
