### PR TITLE
PR-17.5: Replace insecure XOR placeholder with AES-256-GCM AEAD encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,7 +465,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -644,6 +699,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +801,15 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1009,6 +1083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1340,15 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rangemap"
@@ -1567,6 +1668,7 @@ dependencies = [
 name = "storage"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "alayasiki-core",
  "bytecheck",
  "bytes",
@@ -1574,6 +1676,7 @@ dependencies = [
  "dashmap",
  "rkyv",
  "serde",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1586,6 +1689,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1915,6 +2024,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -745,6 +746,24 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1674,6 +1693,7 @@ dependencies = [
  "bytes",
  "crc32fast",
  "dashmap",
+ "hkdf",
  "rkyv",
  "serde",
  "sha2",

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -534,13 +534,13 @@
 
 * Depends on: PR-10, PR-08, PR-17.4
 
-- [ ] **AEAD暗号への置換**: `KmsHookCipher` の XOR プレースホルダを本番用 AEAD 暗号（AES-256-GCM 等）に置換し、保存時暗号化を実装完成させる (Issue #49)
+- [x] **AEAD暗号への置換**: `KmsHookCipher` の XOR プレースホルダを本番用 AEAD 暗号（AES-256-GCM 等）に置換し、保存時暗号化を実装完成させる (Issue #49)
 - [ ] **LLMによる回答合成**: `generate_answer` を単純な文字列結合から LLM による論理的合成へアップグレードし、回答の一貫性・根拠付けを改善する (Issue #50)
-- [ ] **暗号化回帰テスト**: WAL/スナップショットの暗号化・復号経路を網羅する回帰テストを追加
+- [x] **暗号化回帰テスト**: WAL/スナップショットの暗号化・復号経路を網羅する回帰テストを追加
 - [ ] **回答品質評価**: LLM合成後の `groundedness` スコアと `evidence_attachment_rate` が PR-14.6 ベースライン以上を維持することをCIで検証
 
 **Done Criteria:**
-- [ ] XOR プレースホルダが本番コードパスから排除され、AEAD実装に置換される
+- [x] XOR プレースホルダが本番コードパスから排除され、AEAD実装に置換される
 - [ ] `generate_answer` がLLM呼び出しを経由した回答を返却し、既存のgroundednessテストが通過する
 
 ---

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = "3.3"
 serde = { version = "1.0", features = ["derive"] }
 aes-gcm = "0.10"
 sha2 = "0.10"
+hkdf = "0.12"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 usearch = { version = "2", optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -19,6 +19,9 @@ bytes = "1.0"
 tracing = "0.1"
 tempfile = "3.3"
 serde = { version = "1.0", features = ["derive"] }
+aes-gcm = "0.10"
+sha2 = "0.10"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 usearch = { version = "2", optional = true }
+

--- a/storage/src/crypto.rs
+++ b/storage/src/crypto.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Nonce,
+};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -9,6 +14,10 @@ pub enum CryptoError {
     MissingKey(String),
     #[error("kms key must not be empty")]
     EmptyKey,
+    #[error("encryption failure: {0}")]
+    Encryption(String),
+    #[error("decryption failure: {0}")]
+    Decryption(String),
 }
 
 pub trait AtRestCipher: Send + Sync {
@@ -69,9 +78,9 @@ impl KmsKeyProvider for InMemoryKmsKeyProvider {
 
 /// KMS hook cipher for at-rest encryption extension points.
 ///
-/// The current implementation uses XOR to keep the storage path deterministic
-/// and testable; production deployments should replace this with authenticated
-/// encryption backed by a real KMS envelope workflow.
+/// Uses authenticated encryption (AES-256-GCM) with a unique cryptographically
+/// secure random nonce per operation. Data keys of arbitrary size are derived
+/// into a 256-bit key using SHA-256.
 pub struct KmsHookCipher {
     key_id: String,
     key_provider: Arc<dyn KmsKeyProvider>,
@@ -84,37 +93,67 @@ impl KmsHookCipher {
             key_provider,
         }
     }
-
-    fn transform(&self, input: &[u8]) -> Result<Vec<u8>, CryptoError> {
-        let key = self.key_provider.resolve_data_key(&self.key_id)?;
-        xor_payload(input, &key)
-    }
 }
 
 impl AtRestCipher for KmsHookCipher {
     fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
-        self.transform(plaintext)
+        let key = self.key_provider.resolve_data_key(&self.key_id)?;
+        if key.is_empty() {
+            return Err(CryptoError::EmptyKey);
+        }
+
+        // Derive 256-bit key from input key of arbitrary length
+        let mut hasher = Sha256::new();
+        hasher.update(&key);
+        let hashed_key = hasher.finalize();
+
+        let cipher = Aes256Gcm::new(&hashed_key);
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| CryptoError::Encryption(format!("{:?}", e)))?;
+
+        // Prepend 12-byte nonce to the ciphertext
+        let mut result = Vec::with_capacity(nonce.len() + ciphertext.len());
+        result.extend_from_slice(&nonce);
+        result.extend_from_slice(&ciphertext);
+
+        Ok(result)
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
-        self.transform(ciphertext)
+        let key = self.key_provider.resolve_data_key(&self.key_id)?;
+        if key.is_empty() {
+            return Err(CryptoError::EmptyKey);
+        }
+
+        if ciphertext.len() < 12 {
+            return Err(CryptoError::Decryption(
+                "ciphertext too short (must be at least 12 bytes to contain nonce)".to_string(),
+            ));
+        }
+
+        // Derive 256-bit key from input key of arbitrary length
+        let mut hasher = Sha256::new();
+        hasher.update(&key);
+        let hashed_key = hasher.finalize();
+
+        let cipher = Aes256Gcm::new(&hashed_key);
+
+        let (nonce_bytes, encrypted_data) = ciphertext.split_at(12);
+        let nonce = Nonce::from_slice(nonce_bytes);
+
+        let plaintext = cipher
+            .decrypt(nonce, encrypted_data)
+            .map_err(|e| CryptoError::Decryption(format!("{:?}", e)))?;
+
+        Ok(plaintext)
     }
 
     fn key_id(&self) -> Option<&str> {
         Some(self.key_id.as_str())
     }
-}
-
-fn xor_payload(data: &[u8], key: &[u8]) -> Result<Vec<u8>, CryptoError> {
-    if key.is_empty() {
-        return Err(CryptoError::EmptyKey);
-    }
-
-    Ok(data
-        .iter()
-        .enumerate()
-        .map(|(index, byte)| byte ^ key[index % key.len()])
-        .collect())
 }
 
 #[cfg(test)]
@@ -129,10 +168,52 @@ mod tests {
         )])) as Arc<dyn KmsKeyProvider>;
         let cipher = KmsHookCipher::new("kms-1", kms);
 
-        let encrypted = cipher.encrypt(b"payload").unwrap();
-        assert_ne!(encrypted, b"payload");
+        let payload = b"payload";
+        let encrypted = cipher.encrypt(payload).unwrap();
+        assert_ne!(encrypted, payload);
+
+        // AEAD prepends a 12-byte nonce, so ciphertext length must be at least 12 + plaintext.len()
+        assert!(encrypted.len() >= 12 + payload.len());
 
         let decrypted = cipher.decrypt(&encrypted).unwrap();
-        assert_eq!(decrypted, b"payload");
+        assert_eq!(decrypted, payload);
+    }
+
+    #[test]
+    fn kms_hook_cipher_nonce_uniqueness() {
+        let kms = Arc::new(InMemoryKmsKeyProvider::from_keys([(
+            "kms-1",
+            vec![0xAA, 0xBB],
+        )])) as Arc<dyn KmsKeyProvider>;
+        let cipher = KmsHookCipher::new("kms-1", kms);
+
+        let payload = b"same-payload";
+        let enc1 = cipher.encrypt(payload).unwrap();
+        let enc2 = cipher.encrypt(payload).unwrap();
+
+        // Nonces must be unique, meaning ciphertexts must differ
+        assert_ne!(enc1, enc2);
+    }
+
+    #[test]
+    fn kms_hook_cipher_decryption_failure() {
+        let kms = Arc::new(InMemoryKmsKeyProvider::from_keys([(
+            "kms-1",
+            vec![0xAA, 0xBB],
+        )])) as Arc<dyn KmsKeyProvider>;
+        let cipher = KmsHookCipher::new("kms-1", kms);
+
+        let mut encrypted = cipher.encrypt(b"my-secret").unwrap();
+        // Tamper with the ciphertext (e.g., flip the last byte)
+        if let Some(last) = encrypted.last_mut() {
+            *last ^= 0xFF;
+        }
+
+        let decrypt_result = cipher.decrypt(&encrypted);
+        assert!(decrypt_result.is_err());
+        assert!(matches!(
+            decrypt_result.unwrap_err(),
+            CryptoError::Decryption(_)
+        ));
     }
 }

--- a/storage/src/crypto.rs
+++ b/storage/src/crypto.rs
@@ -2,11 +2,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aes_gcm::{
-    aead::{Aead, AeadCore, KeyInit, OsRng},
+    aead::{AeadCore, AeadInPlace, KeyInit, OsRng},
     Aes256Gcm, Nonce,
 };
-use sha2::{Digest, Sha256};
+use hkdf::Hkdf;
+use sha2::Sha256;
 use thiserror::Error;
+
+const NONCE_SIZE: usize = 12; // 96-bit nonce for AES-GCM
 
 #[derive(Debug, Error)]
 pub enum CryptoError {
@@ -76,11 +79,23 @@ impl KmsKeyProvider for InMemoryKmsKeyProvider {
     }
 }
 
+// Private helper to derive a cryptographically strong 256-bit symmetric key from an arbitrary length KMS key
+fn derive_key(key: &[u8]) -> Result<aes_gcm::Key<Aes256Gcm>, CryptoError> {
+    if key.is_empty() {
+        return Err(CryptoError::EmptyKey);
+    }
+    let hk = Hkdf::<Sha256>::new(None, key);
+    let mut derived_key = aes_gcm::Key::<Aes256Gcm>::default();
+    hk.expand(&[], &mut derived_key)
+        .map_err(|_| CryptoError::Encryption("KDF expansion failed".to_string()))?;
+    Ok(derived_key)
+}
+
 /// KMS hook cipher for at-rest encryption extension points.
 ///
 /// Uses authenticated encryption (AES-256-GCM) with a unique cryptographically
 /// secure random nonce per operation. Data keys of arbitrary size are derived
-/// into a 256-bit key using SHA-256.
+/// into a 256-bit key using HKDF-SHA256.
 pub struct KmsHookCipher {
     key_id: String,
     key_provider: Arc<dyn KmsKeyProvider>,
@@ -98,57 +113,50 @@ impl KmsHookCipher {
 impl AtRestCipher for KmsHookCipher {
     fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
         let key = self.key_provider.resolve_data_key(&self.key_id)?;
-        if key.is_empty() {
-            return Err(CryptoError::EmptyKey);
-        }
+        let derived_key = derive_key(&key)?;
 
-        // Derive 256-bit key from input key of arbitrary length
-        let mut hasher = Sha256::new();
-        hasher.update(&key);
-        let hashed_key = hasher.finalize();
-
-        let cipher = Aes256Gcm::new(&hashed_key);
+        let cipher = Aes256Gcm::new(&derived_key);
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
 
-        let ciphertext = cipher
-            .encrypt(&nonce, plaintext)
-            .map_err(|e| CryptoError::Encryption(format!("{:?}", e)))?;
-
-        // Prepend 12-byte nonce to the ciphertext
-        let mut result = Vec::with_capacity(nonce.len() + ciphertext.len());
+        // Pre-allocate a single buffer for: Nonce + Plaintext + 16-byte Tag
+        let mut result = Vec::with_capacity(NONCE_SIZE + plaintext.len() + 16);
         result.extend_from_slice(&nonce);
-        result.extend_from_slice(&ciphertext);
+        result.extend_from_slice(plaintext);
 
+        // Encrypt the plaintext payload part in-place
+        let payload_mut = &mut result[NONCE_SIZE..];
+        let tag = cipher
+            .encrypt_in_place_detached(&nonce, &[], payload_mut)
+            .map_err(|_| CryptoError::Encryption("AEAD encryption failed".to_string()))?;
+
+        result.extend_from_slice(&tag);
         Ok(result)
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
         let key = self.key_provider.resolve_data_key(&self.key_id)?;
-        if key.is_empty() {
-            return Err(CryptoError::EmptyKey);
-        }
+        let derived_key = derive_key(&key).map_err(|_| {
+            CryptoError::Decryption("Failed to derive key for decryption".to_string())
+        })?;
 
-        if ciphertext.len() < 12 {
+        if ciphertext.len() < NONCE_SIZE {
             return Err(CryptoError::Decryption(
-                "ciphertext too short (must be at least 12 bytes to contain nonce)".to_string(),
+                "ciphertext too short (must contain nonce)".to_string(),
             ));
         }
 
-        // Derive 256-bit key from input key of arbitrary length
-        let mut hasher = Sha256::new();
-        hasher.update(&key);
-        let hashed_key = hasher.finalize();
+        let cipher = Aes256Gcm::new(&derived_key);
 
-        let cipher = Aes256Gcm::new(&hashed_key);
-
-        let (nonce_bytes, encrypted_data) = ciphertext.split_at(12);
+        let (nonce_bytes, encrypted_payload) = ciphertext.split_at(NONCE_SIZE);
         let nonce = Nonce::from_slice(nonce_bytes);
 
-        let plaintext = cipher
-            .decrypt(nonce, encrypted_data)
-            .map_err(|e| CryptoError::Decryption(format!("{:?}", e)))?;
+        // Copy encrypted payload (ciphertext + tag) to a mutable vector and decrypt in-place
+        let mut buffer = encrypted_payload.to_vec();
+        cipher
+            .decrypt_in_place(nonce, &[], &mut buffer)
+            .map_err(|_| CryptoError::Decryption("AEAD decryption failed".to_string()))?;
 
-        Ok(plaintext)
+        Ok(buffer)
     }
 
     fn key_id(&self) -> Option<&str> {
@@ -173,7 +181,7 @@ mod tests {
         assert_ne!(encrypted, payload);
 
         // AEAD prepends a 12-byte nonce, so ciphertext length must be at least 12 + plaintext.len()
-        assert!(encrypted.len() >= 12 + payload.len());
+        assert!(encrypted.len() >= NONCE_SIZE + payload.len());
 
         let decrypted = cipher.decrypt(&encrypted).unwrap();
         assert_eq!(decrypted, payload);

--- a/storage/tests/wal_crypto_test.rs
+++ b/storage/tests/wal_crypto_test.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
+use alayasiki_core::model::Node;
 use storage::crypto::{InMemoryKmsKeyProvider, KmsHookCipher};
+use storage::repo::Repository;
 use storage::wal::Wal;
 use tempfile::tempdir;
 
@@ -39,4 +41,60 @@ async fn wal_round_trips_payload_with_kms_hook_cipher() {
     .unwrap();
 
     assert_eq!(recovered, vec![b"sensitive-record".to_vec()]);
+}
+
+#[tokio::test]
+async fn repo_encryption_integration_test() {
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("repo.wal");
+
+    let kms_correct = Arc::new(InMemoryKmsKeyProvider::from_keys([(
+        "kms-key-correct",
+        vec![0x01, 0x02, 0x03, 0x04],
+    )]));
+    let cipher_correct = Arc::new(KmsHookCipher::new("kms-key-correct", kms_correct));
+
+    // 1. Write node with correct cipher
+    {
+        let repo = Repository::open_with_cipher(&wal_path, cipher_correct.clone())
+            .await
+            .unwrap();
+        let node = Node::new(
+            42,
+            vec![0.1, 0.2, 0.3],
+            "super-secret-metadata-pii-content".to_string(),
+        );
+        repo.put_node(node).await.unwrap();
+
+        let retrieved = repo.get_node(42).await.unwrap();
+        assert_eq!(retrieved.data, "super-secret-metadata-pii-content");
+    }
+
+    // 2. Assert ciphertext is encrypted on disk and plaintext does not appear
+    let on_disk = tokio::fs::read(&wal_path).await.unwrap();
+    assert!(
+        !on_disk
+            .windows(b"super-secret-metadata-pii-content".len())
+            .any(|w| w == b"super-secret-metadata-pii-content"),
+        "plaintext secret must not appear on disk"
+    );
+
+    // 3. Re-open with correct cipher and verify decryption and replay
+    {
+        let repo = Repository::open_with_cipher(&wal_path, cipher_correct)
+            .await
+            .unwrap();
+        let retrieved = repo.get_node(42).await.unwrap();
+        assert_eq!(retrieved.data, "super-secret-metadata-pii-content");
+    }
+
+    // 4. Try opening with a different key and verify it fails decryption
+    let kms_wrong = Arc::new(InMemoryKmsKeyProvider::from_keys([(
+        "kms-key-wrong",
+        vec![0xFF, 0xFF, 0xFF, 0xFF],
+    )]));
+    let cipher_wrong = Arc::new(KmsHookCipher::new("kms-key-wrong", kms_wrong));
+
+    let reopen_wrong_result = Repository::open_with_cipher(&wal_path, cipher_wrong).await;
+    assert!(reopen_wrong_result.is_err());
 }


### PR DESCRIPTION
Addresses Issue #49.

### Changes
- Replaced the insecure XOR-based encryption placeholder in KmsHookCipher with proper authenticated encryption (AES-256-GCM).
- Added SHA-256 key hashing to map arbitrary length KMS data keys to 256-bit keys, ensuring backward compatibility with existing tests.
- Prepend a unique cryptographically secure 96-bit random nonce to each ciphertext.
- Added comprehensive unit and integration/regression tests for KMS encryption/decryption, wrong key detection, and ciphertext tamper validation.