### PR TITLE
fix(deps): upgrade bytes to 1.12.0 to resolve RUSTSEC-2026-0007 (Issue #60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
Closes #60

## Summary
`cargo audit` reported **RUSTSEC-2026-0007** (integer overflow in `BytesMut::reserve`) for `bytes` 1.11.0, pulled transitively via `tokio 1.49.0` and used directly by `alayasiki-core` and `storage` (both declare `bytes = "1.0"`).

The `"1.0"` requirement already permits `>=1.11.1`, so this is a pure `Cargo.lock` update: `cargo update -p bytes` bumps `bytes` from **1.11.0 → 1.12.0**. No source changes required.

## Acceptance criteria (Issue #60)
- [x] `bytes` >= 1.11.1 in `Cargo.lock` — now **1.12.0**
- [x] `cargo audit`: the bytes advisory (RUSTSEC-2026-0007) is **cleared**. Remaining findings are unrelated and out of scope for this Issue:
  - `lopdf` 0.34.0 (RUSTSEC-2026-0187) — separate advisory, recommends a distinct `lopdf` upgrade
  - `yaml-rust` 0.4.5 unmaintained (RUSTSEC-2024-0320) — tracked by Issue #61
  - `anyhow` 1.0.100 unsoundness (RUSTSEC-2026-0190) — `allowed` warning, awaits upstream fix
- [x] All workspace tests pass

## Diff
Single file changed: `Cargo.lock` (`name = "bytes"`: `1.11.0 -> 1.12.0`). No source code touched.

## Test plan (verification evidence)
```
cargo fmt --all -- --check                       # clean
cargo clippy --all-targets -- -D warnings        # finished, no warnings
cargo build --workspace                          # finished
cargo test --workspace                           # all test binaries: 0 failed
cargo audit                                      # bytes advisory gone (1 vuln + 2 allowed warnings remain, unrelated)
```

## Risks
- Patch/minor bump within the `1.x` line of a foundational crate; risk of regression is low and the full `cargo test --workspace` suite is green.
- Does **not** address the remaining `lopdf`/`yaml-rust`/`anyhow` findings — those need their own Issues/PRs (yaml-rust already has #61).