### PR TITLE
ci(bench): relax flaky operational latency gates (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
           ALAYASIKI_BENCH_WORKERS: "6"
           ALAYASIKI_BENCH_OPS_PER_WORKER: "100"
           ALAYASIKI_BENCH_WRITE_EVERY: "10"
-          ALAYASIKI_BENCH_MAX_READ_P95_MS: "30"
-          ALAYASIKI_BENCH_MAX_WRITE_P95_MS: "200"
-          ALAYASIKI_BENCH_MIN_THROUGHPUT: "250"
+          ALAYASIKI_BENCH_MAX_READ_P95_MS: "50"
+          ALAYASIKI_BENCH_MAX_WRITE_P95_MS: "250"
+          ALAYASIKI_BENCH_MIN_THROUGHPUT: "200"
         run: cargo bench -p prototypes --bench operational_latency_bench
 
   graphrag-bench-gate:


### PR DESCRIPTION
Closes #57

## Purpose
The operational latency benchmark gate (`bench-smoke` CI job) used strict thresholds (read P95 **30ms** / write P95 200ms / throughput 250 ops/s). The 30ms read gate caused **false regressions** under CI scheduling jitter — e.g. a read P95 of `32.132 ms` on standard/virtualized runners — which panicked the bench and blocked unrelated PRs from merging.

## Change
Relax the CI defaults to the values proposed in the issue:
| Gate | Before | After |
|------|--------|-------|
| `ALAYASIKI_BENCH_MAX_READ_P95_MS` | 30 | **50** |
| `ALAYASIKI_BENCH_MAX_WRITE_P95_MS` | 200 | **250** |
| `ALAYASIKI_BENCH_MIN_THROUGHPUT` | 250 | **200** |

The gates are **already configurable** via these env vars in `prototypes/benches/operational_latency_bench.rs` (env override, no gate when unset), so no Rust code change is needed — only the CI defaults are tightened-down flakiness.

## Scope
Single file, 3 values: `.github/workflows/ci.yml`. No behavior change to the benchmark binary itself.

## Acceptance Criteria (#57)
- [x] Thresholds relaxed to reasonable values (50ms read / 250ms write / 200 ops/s)
- [x] Remains configurable via environment variables

## Verification
- `python3 -c yaml.safe_load` → **YAML OK**
- `cargo check -p prototypes --bench operational_latency_bench` → compiles clean
- Smoke run with the new thresholds (smaller workload):
  ```
  read latency:  p50=1.163 ms, p95=7.221 ms, p99=9.520 ms   (< 50 ms  ✓)
  write latency: p50=6.604 ms, p95=41.353 ms, p99=47.131 ms  (< 250 ms ✓)
  throughput: 1105.10 ops/s                                   (> 200    ✓)
  ```
  No assertion panic — env-var wiring and gate logic confirmed.

## Risks / Limitations
- Looser gates could mask a real regression. The chosen values still bound meaningful SLAs and stay well below the previous failure band; tighter per-host tuning remains possible by overriding the `ALAYASIKI_BENCH_*` env vars in a dedicated hardening job if desired.
