### PR TITLE
ci(test): enforce 80% line-coverage gate (Issue #77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: cargo test --workspace
 
   coverage:
-    name: Coverage (cargo-llvm-cov, report-only)
+    name: Coverage (cargo-llvm-cov, 80% line gate)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -101,6 +101,11 @@ jobs:
           name: coverage-lcov
           path: lcov.info
           if-no-files-found: error
+      # Enforce the SPEC §P7 line-coverage target. Runs after artifact upload
+      # so reports remain available for debugging even when the gate fails.
+      # Baseline observed on this job: ~88% lines (see docs/PLAN.md PR-14.9).
+      - name: Enforce line-coverage gate (fail-under-lines 80)
+        run: cargo llvm-cov report --summary-only --fail-under-lines 80
 
   e2e-tests:
     name: E2E Tests (ingest -> query)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -425,15 +425,15 @@
 - [x] **カバレッジジョブ追加**: `cargo-llvm-cov` でワークスペース全体のカバレッジをCIで生成 (Issue #65)
 - [x] **成果物アップロード**: HTML / LCOV レポートを CI artifact として保存 (PR 毎にダウンロード可能)
 - [x] **ローカル手順の文書化**: README に `cargo-llvm-cov` のインストールとレポート生成手順を追記
-- [ ] **閾値ゲートの有効化**: ベースライン計測後に `--fail-under-lines` で 80% 目標を強制 (フォローアップ Issue で追跡)
+- [x] **閾値ゲートの有効化**: CI カバレッジジョブで `cargo llvm-cov report --summary-only --fail-under-lines 80` を実行し SPEC §P7 の 80% 目標を強制 (Issue #77)
 
 **Done Criteria:**
 - [x] カバレッジが PR 毎に CI で見える
-- [ ] ベースライン トリアージ後に閾値ゲートを有効化
+- [x] ベースライン トリアージ後に閾値ゲートを有効化
 
 **Notes:**
 - 現段階では Issue #65 の指針どおり report-only で導入し、`--fail-under-lines` の強制はベースライン確定後のフォローアップに切り出した
-- `cargo llvm-cov --workspace --lib` で取得した現在のベースラインは lib 限定で約 52% lines（統合テスト/E2Eを含めるとさらに変動）。最初の数回の CI 実行結果を見て現実的な閾値（最終的に SPEC §P7 の 80% 目標）を段階的に引き上げる想定
+- **ベースライン実測と閾値決定 (Issue #77):** ワークスペース全体(lib+統合+E2E)の CI 実測値は **87.94% lines** (TOTAL 7719 中 931 missed、ubuntu-latest)。Issue 想定の ~52% は lib 限定時代の旧値。80% 目標を約 8pt の余裕でクリアしているため、SPEC §P7 の 80% をそのまま `--fail-under-lines 80` で強制する（破滅的低下のスモークゲート兼目標履行）。成果物DXのためゲートステップは LCOV/HTML アップロード後に配置し、失敗時にもレポートがダウンロード可能。カバレッジ向上に合わせて 80 → 85 → 88% へ段階的に引き上げる想定
 - 既存の `cargo-audit` ジョブと揃えるため `taiki-e/install-action@v2` 経由で `cargo-llvm-cov` をインストールし、`dtolnay/rust-toolchain@stable` には `llvm-tools-preview` コンポーネントを追加した
 
 ---


### PR DESCRIPTION
Closes #77

## Summary

Issue #77 tracked the coverage-threshold-gate follow-up to PR #76 (the report-only `cargo-llvm-cov` pipeline). This PR enables `--fail-under-lines` enforcement in the existing coverage CI job, directly satisfying the SPEC §P7 80% line-coverage target.

## Baseline triage (AC task 1)

The issue assumed a ~52% baseline (lib-only, pre-integration-tests). The actual **workspace-wide** (lib + integration + E2E) line coverage measured on the CI coverage job is:

| Source | TOTAL lines | Missed | Line coverage |
|---|---|---|---|
| CI (ubuntu-latest, run of main) | 7719 | 931 | **87.94%** |
| Local (macOS, this branch) | 7661 | 930 | **87.86%** |

The baseline already exceeds the SPEC §P7 80% target by ~8 points, so the target can be enforced immediately (no need for the staged ramp-up the issue anticipated).

## Chosen threshold (AC task 2)

`--fail-under-lines 80` — the SPEC §P7 target itself. The ~8-point buffer absorbs the small local↔CI variance (87.86% vs 87.94%) and OS/test-count noise, while still failing on any catastrophic drop. The intent is to raise 80 → 85 → 88% in later steps as coverage improves (tracked in PLAN.md PR-14.9).

## Changes

- `.github/workflows/ci.yml`
  - Renamed job: `Coverage (cargo-llvm-cov, report-only)` → `Coverage (cargo-llvm-cov, 80% line gate)`.
  - Added a **final** step `Enforce line-coverage gate (fail-under-lines 80)` running `cargo llvm-cov report --summary-only --fail-under-lines 80`, placed *after* the LCOV/HTML artifact uploads so reports stay available for debugging even when the gate fails.
- `docs/PLAN.md` (PR-14.9): marked the gate checkbox + Done Criteria done, recorded the measured baseline, threshold rationale, and the planned step-up path.

## Verification (local, cargo-llvm-cov 0.8.7)

```
cargo llvm-cov --workspace --summary-only --fail-under-lines 80   # exit 0 (PASS)
cargo llvm-cov report --summary-only --fail-under-lines 99        # exit 1 (FAIL, sanity)
TOTAL  ...  Lines 7661  Missed 930  87.86%
```

## Acceptance Criteria

- [x] `cargo llvm-cov --workspace --fail-under-lines <N>` runs in the existing coverage CI job (as `report --summary-only --fail-under-lines 80`, the report-time equivalent on existing profdata).
- [x] Threshold (80) documented in `docs/PLAN.md` PR-14.9 with value + rationale.
- [x] PRs that drop coverage below the threshold fail CI (gate step exits non-zero).

## Notes / out of scope

- The coverage-diff comment action (Codecov/Coveralls/`danger`, issue task 4) is intentionally deferred — it requires an external service/token and is a separate concern from the gate itself; the LCOV/HTML artifacts already let reviewers inspect deltas manually.